### PR TITLE
chore: パッケージ名をリリースタグに含めない

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,7 +10,8 @@
           "path": "jsr.json",
           "jsonpath": "$.version"
         }
-      ]
+      ],
+      "include-component-in-tag": false
     }
   }
 }


### PR DESCRIPTION
- タグ名がモノレポ用の表記になっていたので修正
- 既存リリースも併せて修正
- マージされたら以前のタグを消します
- マージされるとv0.4.0のリリースになるはずです